### PR TITLE
Adjust the Earth to have a more CRT feel with cyan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pnpm-debug.log*
 .idea/
 
 *.blend
+.netlify

--- a/src/components/simulation/Earth.ts
+++ b/src/components/simulation/Earth.ts
@@ -13,14 +13,12 @@ export class Earth {
   private texture: THREE.Texture | null = null;
   private rotationSpeed: number;
   private scene: THREE.Scene;
-  private time: number;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
     const config = simulationConfig.earth;
     this.scene = scene;
     this.rotationSpeed = config.rotationSpeed;
     this.geometry = new THREE.SphereGeometry(config.radius, config.segments, config.segments);
-    this.time = 0.0;
 
     // Load texture asynchronously
     const textureLoader = new THREE.TextureLoader();
@@ -46,7 +44,6 @@ export class Earth {
             uGridDensity: { value: 180.0 }, // Grid density (higher = more lines)
             uGridThickness: { value: 0.2 }, // Grid line thickness
             uGridAntialiasWidth: { value: 0.5 }, // Antialiasing width for smooth grid edges
-            uTime: { value: this.time },
           },
           transparent: false,
           depthTest: true,
@@ -72,11 +69,6 @@ export class Earth {
   update(delta: number): void {
     if (this.mesh) {
       this.mesh.rotation.y += this.rotationSpeed * delta;
-    }
-
-    if (this.material) {
-      this.time += delta;
-      this.material.uniforms.uTime.value = this.time; 
     }
   }
 

--- a/src/components/simulation/Earth.ts
+++ b/src/components/simulation/Earth.ts
@@ -13,12 +13,14 @@ export class Earth {
   private texture: THREE.Texture | null = null;
   private rotationSpeed: number;
   private scene: THREE.Scene;
+  private time: number;
 
   constructor(scene: THREE.Scene, renderer: THREE.WebGLRenderer) {
     const config = simulationConfig.earth;
     this.scene = scene;
     this.rotationSpeed = config.rotationSpeed;
     this.geometry = new THREE.SphereGeometry(config.radius, config.segments, config.segments);
+    this.time = 0.0;
 
     // Load texture asynchronously
     const textureLoader = new THREE.TextureLoader();
@@ -45,6 +47,7 @@ export class Earth {
             uGridThickness: { value: 0.2 }, // Grid line thickness
             uGridAntialiasWidth: { value: 0.5 }, // Antialiasing width for smooth grid edges
             uGridColor: { value: new THREE.Color(simulationConfig.baseColor) }, // Bright neon CRT green
+            uTime: { value: this.time },
           },
           transparent: false,
           depthTest: true,
@@ -70,6 +73,11 @@ export class Earth {
   update(delta: number): void {
     if (this.mesh) {
       this.mesh.rotation.y += this.rotationSpeed * delta;
+    }
+
+    if (this.material) {
+      this.time += delta;
+      this.material.uniforms.uTime.value = this.time; 
     }
   }
 

--- a/src/components/simulation/Earth.ts
+++ b/src/components/simulation/Earth.ts
@@ -41,7 +41,7 @@ export class Earth {
           fragmentShader: earthCRTFragmentShader,
           uniforms: {
             uTexture: { value: texture },
-            uGridDensity: { value: 120.0 }, // Grid density (higher = more lines)
+            uGridDensity: { value: 180.0 }, // Grid density (higher = more lines)
             uGridThickness: { value: 0.2 }, // Grid line thickness
             uGridAntialiasWidth: { value: 0.5 }, // Antialiasing width for smooth grid edges
             uGridColor: { value: new THREE.Color(simulationConfig.baseColor) }, // Bright neon CRT green

--- a/src/components/simulation/Earth.ts
+++ b/src/components/simulation/Earth.ts
@@ -46,7 +46,6 @@ export class Earth {
             uGridDensity: { value: 180.0 }, // Grid density (higher = more lines)
             uGridThickness: { value: 0.2 }, // Grid line thickness
             uGridAntialiasWidth: { value: 0.5 }, // Antialiasing width for smooth grid edges
-            uGridColor: { value: new THREE.Color(simulationConfig.baseColor) }, // Bright neon CRT green
             uTime: { value: this.time },
           },
           transparent: false,

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -48,14 +48,14 @@ export const earthCRTFragmentShader = `
     color = mix(color, uGridColor, gridLine);
 
     // Apply the cyan effect
-    float cyanEdge = 0.05;
     // Define three bands for the cyan effect
     vec2 bands[3];
     bands[0] = vec2(0.0, 0.03);
     bands[1] = vec2(0.3, 0.33);
     bands[2] = vec2(0.67, 0.70);
-    float tCyan = 0.0;
 
+    float cyanEdge = 0.05;
+    float tCyan = 0.0;
     float timeAdj = remap(sin(0.2 * uTime), -1.0, 1.0, 0.0, 1.0);
     for (int i = 0; i < 3; ++i) {
       vec2 band = bands[i];
@@ -66,6 +66,7 @@ export const earthCRTFragmentShader = `
       t = remap(t, 0.0, 1.0, 0.0, 1.0);
       tCyan += t;
     }
+    // TODO: Could also adjust the intensity of the cyan randomly or over time
     tCyan = clamp(tCyan, 0.0, 1.0);
     color = mix(color, CYAN, tCyan * gridLine);
 

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -19,7 +19,7 @@ export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
   const vec3 GRID_COLOR = vec3(0.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
-  const vec3 RED = vec3(0.99, 0.35, 0.35);
+  const vec3 RED = vec3(0.99, 0.45, 0.45);
 
   // Band configuration
   const float BAND_EDGE_WIDTH = 0.04;
@@ -94,7 +94,7 @@ export const earthCRTFragmentShader = `
 
     // Apply red bands
     for (int i = 0; i < NUM_RED_BANDS; i++) {
-      vec2 band = vec2(RED_BANDS[i], RED_BANDS[i] + 0.003);
+      vec2 band = vec2(RED_BANDS[i], RED_BANDS[i] + 0.002);
       float t = applyBand(band, BAND_EDGE_WIDTH);
       // color = mix(color, RED, t * gridLine * (0.6 + vUv.y));
       color = mix(color, RED, t * gridLine);

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -19,26 +19,28 @@ export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
   const vec3 GRID_COLOR = vec3(0.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
-  const vec3 RED = vec3(0.95, 0.65, 0.65);
+  const vec3 RED = vec3(0.99, 0.55, 0.55);
 
   // Band configuration
   const float BAND_EDGE_WIDTH = 0.04;
-  const int NUM_RED_BANDS = 4;
+  const int NUM_RED_BANDS = 6;
   const int NUM_CYAN_BANDS = 3;
   
   // Red band positions (y-coordinate ranges)
-  const vec2 RED_BANDS[NUM_RED_BANDS] = vec2[](
-    vec2(0.70, 0.71),
-    vec2(0.65, 0.66),
-    vec2(0.72, 0.73),
-    vec2(0.77, 0.78)
+  const float RED_BANDS[NUM_RED_BANDS] = float[](
+    0.52,
+    0.55,
+    0.65,
+    0.70,
+    0.73,
+    0.78
   );
   
   // Cyan band positions (y-coordinate ranges)
   const vec2 CYAN_BANDS[NUM_CYAN_BANDS] = vec2[](
-    vec2(0.66, 0.70),
     vec2(0.53, 0.55),
-    vec2(0.75, 0.76)
+    vec2(0.66, 0.70),
+    vec2(0.75, 0.77)
   );
 
   uniform sampler2D uTexture;
@@ -84,8 +86,9 @@ export const earthCRTFragmentShader = `
 
     // Apply red bands
     for (int i = 0; i < NUM_RED_BANDS; i++) {
-      float t = applyBand(RED_BANDS[i], BAND_EDGE_WIDTH);
-      color = mix(color, RED, t * gridLine);
+      vec2 band = vec2(RED_BANDS[i], RED_BANDS[i] + 0.01);
+      float t = applyBand(band, BAND_EDGE_WIDTH);
+      color = mix(color, RED, t * gridLine * (0.6 + vUv.y));
     }
 
     // Apply cyan bands

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -17,12 +17,21 @@ export const earthCRTVertexShader = `
  */
 export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.15);
+  const vec3 CYAN = vec3(0.0, 1.0, 1.0);
   uniform sampler2D uTexture;
   uniform float uGridDensity;
   uniform float uGridThickness;
   uniform float uGridAntialiasWidth;
   uniform vec3 uGridColor;
   varying vec2 vUv;
+
+  float inverseLerp(float value, float inMin, float inMax) {
+    return (value - inMin) / (inMax - inMin);
+  }
+  
+  float remap(float value, float inMin, float inMax, float outMin, float outMax) {
+    return inverseLerp(value, inMin, inMax) * (outMax - outMin) + outMin;
+  }
 
   void main() {
     vec3 color = BG_COLOR;
@@ -38,6 +47,13 @@ export const earthCRTFragmentShader = `
     color = mix(color, uGridColor, gridLine);
 
     // Apply the cyan effect
+    float cyanEdge = 0.05;
+    vec2 band = vec2(0.7, 0.9);
+    float t1 =
+      smoothstep(band.x - cyanEdge, band.x + cyanEdge, vUv.y) * 
+      (1.0 - smoothstep(band.y - cyanEdge, band.y + cyanEdge, vUv.y));
+    t1 = remap(t1, 0.0, 1.0, 0.0, 1.0);
+    color = mix(color, CYAN, t1 * gridLine);
 
     // Mask out water to the background color
     vec4 texture = texture2D(uTexture, vUv);

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -19,28 +19,36 @@ export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
   const vec3 GRID_COLOR = vec3(0.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
-  const vec3 RED = vec3(0.99, 0.55, 0.55);
+  const vec3 RED = vec3(0.99, 0.35, 0.35);
 
   // Band configuration
   const float BAND_EDGE_WIDTH = 0.04;
-  const int NUM_RED_BANDS = 6;
-  const int NUM_CYAN_BANDS = 3;
+  const int NUM_RED_BANDS = 11;
+  const int NUM_CYAN_BANDS = 6;
   
   // Red band positions (y-coordinate ranges)
   const float RED_BANDS[NUM_RED_BANDS] = float[](
+    0.08,
+    0.24,
+    0.27,
+    0.39,
+    0.42,
     0.52,
     0.55,
     0.65,
     0.70,
-    0.73,
-    0.78
+    0.79,
+    0.83
   );
   
   // Cyan band positions (y-coordinate ranges)
   const vec2 CYAN_BANDS[NUM_CYAN_BANDS] = vec2[](
+    vec2(0.05, 0.08),
+    vec2(0.25, 0.27),
+    vec2(0.40, 0.43),
     vec2(0.53, 0.55),
     vec2(0.66, 0.70),
-    vec2(0.75, 0.77)
+    vec2(0.80, 0.83)
   );
 
   uniform sampler2D uTexture;
@@ -86,9 +94,10 @@ export const earthCRTFragmentShader = `
 
     // Apply red bands
     for (int i = 0; i < NUM_RED_BANDS; i++) {
-      vec2 band = vec2(RED_BANDS[i], RED_BANDS[i] + 0.01);
+      vec2 band = vec2(RED_BANDS[i], RED_BANDS[i] + 0.003);
       float t = applyBand(band, BAND_EDGE_WIDTH);
-      color = mix(color, RED, t * gridLine * (0.6 + vUv.y));
+      // color = mix(color, RED, t * gridLine * (0.6 + vUv.y));
+      color = mix(color, RED, t * gridLine);
     }
 
     // Apply cyan bands

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -16,8 +16,8 @@ export const earthCRTVertexShader = `
  * Converts greenish pixels to black and overlays green grid on white areas
  */
 export const earthCRTFragmentShader = `
-  const vec3 BG_COLOR = vec3(0.15, 0.15, 0.15);
-  const vec3 GRID_COLOR = vec3(.99, 0.94, 0.93);
+  const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
+  const vec3 GRID_COLOR = vec3(.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
 
   uniform sampler2D uTexture;

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -17,7 +17,7 @@ export const earthCRTVertexShader = `
  */
 export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
-  const vec3 GRID_COLOR = vec3(.99, 0.92, 0.92);
+  const vec3 GRID_COLOR = vec3(0.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
 
   uniform sampler2D uTexture;

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -19,6 +19,7 @@ export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.16, 0.15, 0.15);
   const vec3 GRID_COLOR = vec3(0.99, 0.92, 0.92);
   const vec3 CYAN = vec3(0.55, 0.95, 0.95);
+  const vec3 RED = vec3(0.95, 0.65, 0.65);
 
   uniform sampler2D uTexture;
   uniform float uGridDensity;
@@ -62,6 +63,24 @@ export const earthCRTFragmentShader = `
     float gridLine = 1.0 - smoothstep(edge0, edge1, gridDist);
     color = mix(color, GRID_COLOR, gridLine);
 
+    // Red bands
+    vec2 redBand = vec2(0.70, 0.71);
+    float tRed = applyBand(redBand);
+    color = mix(color, RED, tRed * gridLine);
+
+    redBand = vec2(0.65, 0.66);
+    tRed = applyBand(redBand);
+    color = mix(color, RED, tRed * gridLine);
+
+    redBand = vec2(0.72, 0.73);
+    tRed = applyBand(redBand);
+    color = mix(color, RED, tRed * gridLine);
+
+    redBand = vec2(0.77, 0.78);
+    tRed = applyBand(redBand);
+    color = mix(color, RED, tRed * gridLine);
+
+    // Cyan bands
     vec2 cyanBand = vec2(0.66, 0.70);
     float tCyan = applyBand(cyanBand);
     color = mix(color, CYAN, tCyan * gridLine);
@@ -73,6 +92,7 @@ export const earthCRTFragmentShader = `
     cyanBand = vec2(0.75, 0.76);
     tCyan = applyBand(cyanBand);
     color = mix(color, CYAN, tCyan * gridLine);
+
 
     // Mask out water to the background color
     vec4 texture = texture2D(uTexture, vUv);

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -17,7 +17,7 @@ export const earthCRTVertexShader = `
  */
 export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.15);
-  const vec3 CYAN = vec3(0.1, 0.75, 0.75);
+  const vec3 CYAN = vec3(0.55, 1.00, 1.00);
   uniform sampler2D uTexture;
   uniform float uGridDensity;
   uniform float uGridThickness;
@@ -56,19 +56,21 @@ export const earthCRTFragmentShader = `
 
     float cyanEdge = 0.05;
     float tCyan = 0.0;
-    float timeAdj = remap(sin(0.2 * uTime), -1.0, 1.0, 0.0, 1.0);
     for (int i = 0; i < 3; ++i) {
       vec2 band = bands[i];
-      band = fract(band + timeAdj);
       float t =
         smoothstep(band.x - cyanEdge, band.x + cyanEdge, vUv.y) *
         (1.0 - smoothstep(band.y - cyanEdge, band.y + cyanEdge, vUv.y));
       t = remap(t, 0.0, 1.0, 0.0, 1.0);
       tCyan += t;
     }
-    // TODO: Could also adjust the intensity of the cyan randomly or over time
+    
     tCyan = clamp(tCyan, 0.0, 1.0);
     color = mix(color, CYAN, tCyan * gridLine);
+
+    // Add in the red.
+    // TODO: localize the red to around the bands
+    color = mix(color, vec3(1.0, 0.85, 0.85), gridLine * (1.0 - tCyan));
 
     // Mask out water to the background color
     vec4 texture = texture2D(uTexture, vUv);

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -17,7 +17,7 @@ export const earthCRTVertexShader = `
  */
 export const earthCRTFragmentShader = `
   const vec3 BG_COLOR = vec3(0.15);
-  const vec3 CYAN = vec3(0.0, 1.0, 1.0);
+  const vec3 CYAN = vec3(0.1, 0.75, 0.75);
   uniform sampler2D uTexture;
   uniform float uGridDensity;
   uniform float uGridThickness;
@@ -51,13 +51,15 @@ export const earthCRTFragmentShader = `
     float cyanEdge = 0.05;
     // Define three bands for the cyan effect
     vec2 bands[3];
-    bands[0] = vec2(0.0, 0.05);
-    bands[1] = vec2(0.3, 0.35);
-    bands[2] = vec2(0.65, 0.70);
+    bands[0] = vec2(0.0, 0.03);
+    bands[1] = vec2(0.3, 0.33);
+    bands[2] = vec2(0.67, 0.70);
     float tCyan = 0.0;
+
+    float timeAdj = remap(sin(0.2 * uTime), -1.0, 1.0, 0.0, 1.0);
     for (int i = 0; i < 3; ++i) {
       vec2 band = bands[i];
-      band = fract(band + sin(.1 * uTime));
+      band = fract(band + timeAdj);
       float t =
         smoothstep(band.x - cyanEdge, band.x + cyanEdge, vUv.y) *
         (1.0 - smoothstep(band.y - cyanEdge, band.y + cyanEdge, vUv.y));

--- a/src/components/simulation/shaders/earthCRTShaders.ts
+++ b/src/components/simulation/shaders/earthCRTShaders.ts
@@ -24,7 +24,6 @@ export const earthCRTFragmentShader = `
   uniform float uGridDensity;
   uniform float uGridThickness;
   uniform float uGridAntialiasWidth;
-  uniform float uTime;
   varying vec2 vUv;
 
   float inverseLerp(float value, float inMin, float inMax) {


### PR DESCRIPTION
Uses the mp4 from December 3 as a reference guide.

Demo: https://2026-01-06-07-57-demo.netlify.app/

- Added a cyan bands and a bit of red into the Earth colors.
- Remove anti-aliasing from the shader so the grid lines are less perfectly smooth and more CRT-like.
- Increased the number of grid lines (proportional to the size of the Earth sphere compared to the December video).