### PR TITLE
Expand jobs listings and add updates signup

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,41 @@
 <footer class="site-footer">
     <div class="site-footer__inner | repel">
-        <p>
-            Cosmic Frontier Labs
-            <br />
-            USA, Earth, Milky Way, Laniakea Supercluster
-        </p>
+        <div class="site-footer__brand">
+            <p>
+                Cosmic Frontier Labs
+                <br />
+                USA, Earth, Milky Way, Laniakea Supercluster
+            </p>
+        </div>
+        <div class="site-footer__signup flow">
+            <h2 class="site-footer__signup-title">Get updates</h2>
+            <p class="site-footer__signup-copy">Sign up for mission updates and new roles.</p>
+            <form class="site-footer__signup-form" data-newsletter-form>
+                <label class="visually-hidden" for="updates-email">Email address</label>
+                <input
+                    id="updates-email"
+                    name="email"
+                    type="email"
+                    autocomplete="email"
+                    placeholder="you@example.com"
+                    required
+                />
+                <button class="button" type="submit" data-smaller>Join list</button>
+            </form>
+            <p class="site-footer__signup-note">No email provider yet. This opens your email client.</p>
+        </div>
     </div>
+    <script is:inline>
+        const form = document.querySelector("[data-newsletter-form]");
+        if (form instanceof HTMLFormElement) {
+            form.addEventListener("submit", (event) => {
+                event.preventDefault();
+                const emailInput = form.querySelector('input[name="email"]');
+                const email = emailInput instanceof HTMLInputElement ? emailInput.value.trim() : "";
+                const subject = encodeURIComponent("Updates list signup");
+                const body = encodeURIComponent(`Please add me to the updates list.\n\nEmail: ${email}`);
+                window.location.href = `mailto:contact@cosmicfrontier.org?subject=${subject}&body=${body}`;
+            });
+        }
+    </script>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,3 +1,16 @@
+---
+const kitFormOptions = {
+    settings: {
+        after_subscribe: {
+            action: "message",
+            success_message: "Success! You’re on the list.",
+            redirect_url: "",
+        },
+    },
+    version: "5",
+};
+---
+
 <footer class="site-footer">
     <div class="site-footer__inner | repel">
         <div class="site-footer__brand">
@@ -18,19 +31,26 @@
                 data-uid="170ae5b1d6"
                 data-format="inline"
                 data-version="5"
+                data-options={JSON.stringify(kitFormOptions)}
             >
-                <label class="visually-hidden" for="updates-email">Email address</label>
-                <input
-                    id="updates-email"
-                    name="email_address"
-                    type="email"
-                    autocomplete="email"
-                    placeholder="you@example.com"
-                    required
-                />
-                <button class="button" type="submit" data-smaller>Join list</button>
+                <div class="site-footer__signup-shell" data-style="clean">
+                    <ul class="site-footer__signup-alert formkit-alert formkit-alert-error" data-element="errors" data-group="alert"></ul>
+                    <div class="site-footer__signup-fields" data-element="fields" data-stacked="false">
+                        <label class="visually-hidden" for="updates-email">Email address</label>
+                        <input
+                            id="updates-email"
+                            name="email_address"
+                            type="email"
+                            autocomplete="email"
+                            placeholder="you@example.com"
+                            required
+                        />
+                        <button class="button formkit-submit" type="submit" data-element="submit" data-smaller>
+                            Join list
+                        </button>
+                    </div>
+                </div>
             </form>
-            <p class="site-footer__signup-note">Check your inbox to confirm.</p>
         </div>
     </div>
     <script src="https://f.convertkit.com/ckjs/ck.5.js" async></script>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,11 +10,19 @@
         <div class="site-footer__signup flow">
             <h2 class="site-footer__signup-title">Get updates</h2>
             <p class="site-footer__signup-copy">Sign up for mission updates and new roles.</p>
-            <form class="site-footer__signup-form" data-newsletter-form>
+            <form
+                class="site-footer__signup-form formkit-form"
+                action="https://app.kit.com/forms/8948798/subscriptions"
+                method="post"
+                data-sv-form="8948798"
+                data-uid="170ae5b1d6"
+                data-format="inline"
+                data-version="5"
+            >
                 <label class="visually-hidden" for="updates-email">Email address</label>
                 <input
                     id="updates-email"
-                    name="email"
+                    name="email_address"
                     type="email"
                     autocomplete="email"
                     placeholder="you@example.com"
@@ -22,20 +30,8 @@
                 />
                 <button class="button" type="submit" data-smaller>Join list</button>
             </form>
-            <p class="site-footer__signup-note">No email provider yet. This opens your email client.</p>
+            <p class="site-footer__signup-note">Check your inbox to confirm.</p>
         </div>
     </div>
-    <script is:inline>
-        const form = document.querySelector("[data-newsletter-form]");
-        if (form instanceof HTMLFormElement) {
-            form.addEventListener("submit", (event) => {
-                event.preventDefault();
-                const emailInput = form.querySelector('input[name="email"]');
-                const email = emailInput instanceof HTMLInputElement ? emailInput.value.trim() : "";
-                const subject = encodeURIComponent("Updates list signup");
-                const body = encodeURIComponent(`Please add me to the updates list.\n\nEmail: ${email}`);
-                window.location.href = `mailto:contact@cosmicfrontier.org?subject=${subject}&body=${body}`;
-            });
-        }
-    </script>
+    <script src="https://f.convertkit.com/ckjs/ck.5.js" async></script>
 </footer>

--- a/src/site-content/jobs.yaml
+++ b/src/site-content/jobs.yaml
@@ -160,6 +160,24 @@
     If you love breaking things before they break themselves, we want to talk.
   isDraft: false
 
+- title: "Intern"
+  location: "SF Bay Area"
+  description: |
+    We’re looking for interns across engineering and science. Any job listed above can be an internship depending on timing and fit.
+
+    You will
+    - Work alongside the team shipping real hardware and software
+    - Take ownership of a scoped project with clear success criteria
+    - Learn fast, document what you learned, and make the next build better
+
+    In your first 90 days
+    - Ramp on a subsystem and deliver a useful artifact (design, analysis, test, or code)
+    - Present your work and what you would do next
+    - Leave behind documentation or tooling that makes the team faster
+
+    If you want to build real space hardware and learn by doing, we want to talk.
+  isDraft: false
+
 - title: "Write Your Own Role"
   location: "SF Bay Area"
   description: |

--- a/src/styles/blocks/site-footer.css
+++ b/src/styles/blocks/site-footer.css
@@ -13,3 +13,40 @@
   height: 100%;
   padding-block-end: var(--space-l);
 }
+
+.site-footer__brand {
+  max-width: 28ch;
+}
+
+.site-footer__signup {
+  max-width: 28rem;
+}
+
+.site-footer__signup-title {
+  font-size: var(--size-step-0);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.site-footer__signup-copy {
+  margin: 0;
+}
+
+.site-footer__signup-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.site-footer__signup-note {
+  margin: 0;
+  font-size: var(--size-step--2);
+  color: var(--color-text-mid);
+}
+
+@media (max-width: 40rem) {
+  .site-footer__signup-form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/blocks/site-footer.css
+++ b/src/styles/blocks/site-footer.css
@@ -22,6 +22,30 @@
   max-width: 28rem;
 }
 
+.site-footer__signup-shell {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.site-footer__signup-alert {
+  margin: 0;
+  padding: var(--space-xs);
+  border-radius: var(--radius-s);
+  border: 1px solid var(--color-gray-600);
+  background: var(--color-gray-100);
+  color: var(--color-text);
+  font-size: var(--size-step--2);
+  list-style: none;
+}
+
+.site-footer__signup-alert:empty {
+  display: none;
+}
+
+.site-footer__signup-alert.formkit-alert-success {
+  border-color: var(--color-primary);
+}
+
 .site-footer__signup-title {
   font-size: var(--size-step-0);
   text-transform: uppercase;
@@ -34,19 +58,18 @@
 
 .site-footer__signup-form {
   display: grid;
+  gap: var(--space-xs);
+}
+
+.site-footer__signup-fields {
+  display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-xs);
   align-items: center;
 }
 
-.site-footer__signup-note {
-  margin: 0;
-  font-size: var(--size-step--2);
-  color: var(--color-text-mid);
-}
-
 @media (max-width: 40rem) {
-  .site-footer__signup-form {
+  .site-footer__signup-fields {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- expand job postings with new roles and an intern option
- render job descriptions as paragraphs and bullet lists, and move apply instructions near the CTA
- add a footer updates signup form (mailto placeholder)

## Testing
- not run