### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
 


### PR DESCRIPTION
Bumps every `actions/checkout` pin in `.github/` to `v7`, the newest major.

Closes #31

No local testing performed — CI on this PR is the validation.